### PR TITLE
chore: upgrade to dp3t android sdk version 0.2.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,5 +126,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "org.dpppt:dp3t-sdk-android:0.2.3"
+  implementation "org.dpppt:dp3t-sdk-android:0.2.6"
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -23,6 +23,7 @@
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.jetifier.blacklist = bcprov.*\\.jar
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.33.1

--- a/example/src/home/Init.tsx
+++ b/example/src/home/Init.tsx
@@ -139,8 +139,8 @@ export const Init: FunctionComponent = () => {
               backendAppId: 'org.dpppt.demo',
               publicKeyBase64:
                 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0R' +
-                'RZ0FFWTc3MFZEWjJlZjZCYjh0UXZYWVJpcUFaemtHLwpwNWs0U3pTV3FRY00zNzlqTVN6c3JOaU5nc0' +
-                'hWZlRPeGFqMUFzQ3RrNmJVUDV1cDc3RU5nckVzVkh3PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t',
+                'RZ0FFdkxXZHVFWThqcnA4aWNSNEpVSlJaU0JkOFh2UgphR2FLeUg2VlFnTXV2Zk1JcmxrNk92QmtKeH' +
+                'dhbUdNRnFWYW9zOW11di9rWGhZdjF1a1p1R2RjREJBPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t',
               dev: true,
             })
           }


### PR DESCRIPTION
upgrade dp3t android sdk to version 0.2.6
* upgrade in build.gradle
* blacklist bcprov lib having problems with jetfier
* change actual org.dpppt.demo public key